### PR TITLE
Fix 304 response handling

### DIFF
--- a/src/main/java/br/com/allen/flashfood/api/controller/PaymentMethodController.java
+++ b/src/main/java/br/com/allen/flashfood/api/controller/PaymentMethodController.java
@@ -44,7 +44,7 @@ public class PaymentMethodController implements PaymentMethodControllerOpenApi {
     }
 
     if (request.checkNotModified(eTag)) {
-      return null;
+      return ResponseEntity.status(HttpStatus.NOT_MODIFIED).build();
     }
 
     List<PaymentMethod> allPaymentMethods = paymentMehodRepository.findAll();
@@ -69,7 +69,7 @@ public class PaymentMethodController implements PaymentMethodControllerOpenApi {
     }
 
     if (request.checkNotModified(eTag)) {
-      return null;
+      return ResponseEntity.status(HttpStatus.NOT_MODIFIED).build();
     }
     PaymentMethod paymentMethod =
         paymentMethodRegistrationService.findPaymentMethodOrElseThrow(paymentMethodId);


### PR DESCRIPTION
## Summary
- correct HTTP 304 responses in `PaymentMethodController`

## Testing
- `mvnw -q -DskipTests package` *(fails: Could not find or load main class org.apache.maven.wrapper.MavenWrapperMain)*

------
https://chatgpt.com/codex/tasks/task_e_68463ee9aa448320bdf463437a472d0e